### PR TITLE
Adding 061_shortest_path_MATLAB.m 006_binary_search_CPP.hpp 006_binary_search_CPP.cpp 074_shortest_path_Elixir.exs 015_binary_search_Scala.scala 074_shortest_path_Elixir.exs 068_shortest_path_Haskell.hs 070_shortest_path_Lisp.lisp 011_binary_search_GO.go 025_binary_search_VB_NET.vb

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Message
+echo "Cleaning system-specific artifacts..."
+
+# Removendo os arquivos .DS_Store recursivamente.
+find . -name ".DS_Store" -type f -delete
+
+# Removendo qualquer outro arquivo de metadados do MAC (arquivos que começam com "._") recursivamente.
+find . -name "._*" -type f -delete
+
+# Removendo .Trashes and outros que, às vezes, o MAC gera, quando quer.
+find . -name ".Trashes" -type d -exec rm -rf {} +
+
+# Message
+echo "Cleaning Python build artifacts..."
+
+# Remove build directories
+rm -rf build/ dist/ *.egg-info/ .eggs/
+
+# Remove Python cache and compiled files
+find . -type d -name "__pycache__" -exec rm -rf {} +
+find . -type f -name "*.pyc" -delete
+find . -type f -name "*.pyo" -delete
+find . -type f -name "*~" -delete
+
+# Remove test and tool caches
+rm -rf .pytest_cache/ .mypy_cache/ .tox/ .coverage .cache/
+
+echo "Cleanup complete."
+
+

--- a/dev_src/006_binary_search_CPP.cpp
+++ b/dev_src/006_binary_search_CPP.cpp
@@ -1,0 +1,143 @@
+// binary_search.cpp — Binary search in a sorted array (single-file C++17 program)
+//
+// Build:
+//   g++ -O2 -Wall -Wextra -std=c++17 -o binary_search binary_search.cpp
+//
+// Run:
+//   ./binary_search input.txt 1 9 15 2
+//
+// Behavior:
+//   • Reads one integer per line from input.txt (ignores malformed lines).
+//   • Sorts values ascending.
+//   • For each target (CLI args after the file), prints its 1-based index if found; otherwise “not found”.
+//   • If no targets are provided, uses demo targets: 1, 9, 15, 2.
+//
+// Notes:
+//   • Time: O(n log n) to sort + O(log n) per query. Space: O(n) for values.
+//   • Values are int64_t; adjust if you need bigger ranges.
+//   • For very large inputs, consider memory-mapping or on-disk indices.
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// ---- trim helpers (minimal) ----
+static inline std::string_view ltrim(std::string_view s) {
+    while (!s.empty() && (s.front()==' ' || s.front()=='\t' || s.front()=='\r')) s.remove_prefix(1);
+    return s;
+}
+static inline std::string_view rtrim(std::string_view s) {
+    while (!s.empty() && (s.back()==' ' || s.back()=='\t' || s.back()=='\r')) s.remove_suffix(1);
+    return s;
+}
+static inline std::string_view trim(std::string_view s) { return rtrim(ltrim(s)); }
+
+// ---- parse int64 from a whole line; return std::nullopt if bad ----
+static std::optional<int64_t> parse_i64_line(std::string_view line) {
+    line = trim(line);
+    if (line.empty()) return std::nullopt;
+
+    // strtoll needs a c-string; make a copy
+    std::string tmp(line);
+    const char* p = tmp.c_str();
+    char* end = nullptr;
+    errno = 0;
+    long long v = std::strtoll(p, &end, 10);
+    if (errno != 0) return std::nullopt;
+
+    // ensure no trailing junk (allow trailing spaces already trimmed)
+    if (end && *end != '\0') return std::nullopt;
+
+    return static_cast<int64_t>(v);
+}
+
+// ---- iterative binary search; return 1-based index if found, else -1 ----
+static long bin_search(const std::vector<int64_t>& a, int64_t target) {
+    if (a.empty()) return -1;
+    std::size_t lo = 0, hi = a.size() - 1;
+    while (lo <= hi) {
+        std::size_t mid = lo + (hi - lo) / 2;
+        int64_t v = a[mid];
+        if (v == target) return static_cast<long>(mid + 1); // 1-based
+        if (v < target)  lo = mid + 1;
+        else {
+            if (mid == 0) break; // prevent underflow
+            hi = mid - 1;
+        }
+    }
+    return -1;
+}
+
+// ---- load integers from file; ignore malformed lines (warn) ----
+static bool load_values_sorted(const std::string& path, std::vector<int64_t>& out) {
+    std::ifstream in(path);
+    if (!in) {
+        std::cerr << "Error: cannot open '" << path << "'\n";
+        return false;
+    }
+    std::string line;
+    std::size_t lineno = 0;
+    out.clear();
+    out.reserve(4096);
+
+    while (std::getline(in, line)) {
+        ++lineno;
+        auto maybe = parse_i64_line(line);
+        if (maybe.has_value()) {
+            out.push_back(*maybe);
+        } else {
+            // comment the next line if you prefer silence
+            std::cerr << "[skip] line " << lineno << " not an integer: " << line << "\n";
+        }
+    }
+    std::sort(out.begin(), out.end());
+    return true;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr
+            << "Usage: " << argv[0] << " <input.txt> [targets ...]\n"
+            << "Example: " << argv[0] << " input.txt 1 9 15 2\n";
+        return 2;
+    }
+
+    const std::string input_path = argv[1];
+    std::vector<int64_t> values;
+    if (!load_values_sorted(input_path, values)) return 1;
+
+    std::cout << "Loaded " << values.size() << " numbers from " << input_path << "\n";
+
+    // If no targets supplied, use demo set
+    if (argc == 2) {
+        const int64_t demo[] = {1, 9, 15, 2};
+        for (int64_t t : demo) {
+            long idx = bin_search(values, t);
+            if (idx > 0) std::cout << "Target " << t << ": found at index " << idx << "\n";
+            else         std::cout << "Target " << t << ": not found\n";
+        }
+        return 0;
+    }
+
+    // Parse targets from argv
+    for (int i = 2; i < argc; ++i) {
+        std::string_view sv(argv[i]);
+        auto maybe = parse_i64_line(sv);
+        if (!maybe) {
+            std::cerr << "[skip target] not an integer: " << sv << "\n";
+            continue;
+        }
+        long idx = bin_search(values, *maybe);
+        if (idx > 0) std::cout << "Target " << *maybe << ": found at index " << idx << "\n";
+        else         std::cout << "Target " << *maybe << ": not found\n";
+    }
+    return 0;
+}

--- a/dev_src/006_binary_search_CPP.hpp
+++ b/dev_src/006_binary_search_CPP.hpp
@@ -1,0 +1,143 @@
+// binary_search.cpp — Binary search in a sorted array (single-file C++17 program)
+//
+// Build:
+//   g++ -O2 -Wall -Wextra -std=c++17 -o binary_search binary_search.cpp
+//
+// Run:
+//   ./binary_search input.txt 1 9 15 2
+//
+// Behavior:
+//   • Reads one integer per line from input.txt (ignores malformed lines).
+//   • Sorts values ascending.
+//   • For each target (CLI args after the file), prints its 1-based index if found; otherwise “not found”.
+//   • If no targets are provided, uses demo targets: 1, 9, 15, 2.
+//
+// Notes:
+//   • Time: O(n log n) to sort + O(log n) per query. Space: O(n) for values.
+//   • Values are int64_t; adjust if you need bigger ranges.
+//   • For very large inputs, consider memory-mapping or on-disk indices.
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// ---- trim helpers (minimal) ----
+static inline std::string_view ltrim(std::string_view s) {
+    while (!s.empty() && (s.front()==' ' || s.front()=='\t' || s.front()=='\r')) s.remove_prefix(1);
+    return s;
+}
+static inline std::string_view rtrim(std::string_view s) {
+    while (!s.empty() && (s.back()==' ' || s.back()=='\t' || s.back()=='\r')) s.remove_suffix(1);
+    return s;
+}
+static inline std::string_view trim(std::string_view s) { return rtrim(ltrim(s)); }
+
+// ---- parse int64 from a whole line; return std::nullopt if bad ----
+static std::optional<int64_t> parse_i64_line(std::string_view line) {
+    line = trim(line);
+    if (line.empty()) return std::nullopt;
+
+    // strtoll needs a c-string; make a copy
+    std::string tmp(line);
+    const char* p = tmp.c_str();
+    char* end = nullptr;
+    errno = 0;
+    long long v = std::strtoll(p, &end, 10);
+    if (errno != 0) return std::nullopt;
+
+    // ensure no trailing junk (allow trailing spaces already trimmed)
+    if (end && *end != '\0') return std::nullopt;
+
+    return static_cast<int64_t>(v);
+}
+
+// ---- iterative binary search; return 1-based index if found, else -1 ----
+static long bin_search(const std::vector<int64_t>& a, int64_t target) {
+    if (a.empty()) return -1;
+    std::size_t lo = 0, hi = a.size() - 1;
+    while (lo <= hi) {
+        std::size_t mid = lo + (hi - lo) / 2;
+        int64_t v = a[mid];
+        if (v == target) return static_cast<long>(mid + 1); // 1-based
+        if (v < target)  lo = mid + 1;
+        else {
+            if (mid == 0) break; // prevent underflow
+            hi = mid - 1;
+        }
+    }
+    return -1;
+}
+
+// ---- load integers from file; ignore malformed lines (warn) ----
+static bool load_values_sorted(const std::string& path, std::vector<int64_t>& out) {
+    std::ifstream in(path);
+    if (!in) {
+        std::cerr << "Error: cannot open '" << path << "'\n";
+        return false;
+    }
+    std::string line;
+    std::size_t lineno = 0;
+    out.clear();
+    out.reserve(4096);
+
+    while (std::getline(in, line)) {
+        ++lineno;
+        auto maybe = parse_i64_line(line);
+        if (maybe.has_value()) {
+            out.push_back(*maybe);
+        } else {
+            // comment the next line if you prefer silence
+            std::cerr << "[skip] line " << lineno << " not an integer: " << line << "\n";
+        }
+    }
+    std::sort(out.begin(), out.end());
+    return true;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr
+            << "Usage: " << argv[0] << " <input.txt> [targets ...]\n"
+            << "Example: " << argv[0] << " input.txt 1 9 15 2\n";
+        return 2;
+    }
+
+    const std::string input_path = argv[1];
+    std::vector<int64_t> values;
+    if (!load_values_sorted(input_path, values)) return 1;
+
+    std::cout << "Loaded " << values.size() << " numbers from " << input_path << "\n";
+
+    // If no targets supplied, use demo set
+    if (argc == 2) {
+        const int64_t demo[] = {1, 9, 15, 2};
+        for (int64_t t : demo) {
+            long idx = bin_search(values, t);
+            if (idx > 0) std::cout << "Target " << t << ": found at index " << idx << "\n";
+            else         std::cout << "Target " << t << ": not found\n";
+        }
+        return 0;
+    }
+
+    // Parse targets from argv
+    for (int i = 2; i < argc; ++i) {
+        std::string_view sv(argv[i]);
+        auto maybe = parse_i64_line(sv);
+        if (!maybe) {
+            std::cerr << "[skip target] not an integer: " << sv << "\n";
+            continue;
+        }
+        long idx = bin_search(values, *maybe);
+        if (idx > 0) std::cout << "Target " << *maybe << ": found at index " << idx << "\n";
+        else         std::cout << "Target " << *maybe << ": not found\n";
+    }
+    return 0;
+}

--- a/dev_src/011_binary_search_GO.go
+++ b/dev_src/011_binary_search_GO.go
@@ -1,0 +1,200 @@
+// binary_search_cli.go
+//
+// Binary search over a sorted (ascending) list of numbers.
+// - Works as a CLI:  go run binary_search_cli.go <target> [path/to/file]
+//   • If <file> is omitted, the program reads numbers from STDIN (one per line).
+// - Works as a library-like function too: see binarySearch() below.
+//
+// Behavior
+//   • O(log N) classic binary search.
+//   • Returns FIRST occurrence if duplicates exist (stable-left).
+//   • On hit:  prints  FOUND <target> at index <i> (1-based)
+//   • On miss: prints  NOT FOUND <target>. Insertion index <i> (1-based), between <left> and <right>
+//
+// Input requirements
+//   • Non-decreasing order (ascending, duplicates allowed). Program validates and errors out if violated.
+//
+// Build & Run examples
+//   go run binary_search_cli.go 11 data.txt
+//   printf "1\n3\n4\n7\n9\n11\n15\n" | go run binary_search_cli.go 11
+//   go build -o bsearch && ./bsearch 5 data.txt
+//
+// Notes
+//   • Uses float64 for generality. Change to int if desired.
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// -----------------------------
+// Core algorithm (library API)
+// -----------------------------
+
+// binarySearch performs binary search over ascending slice `arr` for `target`.
+// Returns (idx, found, insertPos) where:
+//   - idx       : 1-based index if found, else 0
+//   - found     : true if an exact match exists
+//   - insertPos : 1-based position where `target` should be inserted to keep order (always valid)
+func binarySearch(arr []float64, target float64) (int, bool, int) {
+	lo, hi := 0, len(arr)-1
+	foundIdx := -1
+
+	for lo <= hi {
+		mid := lo + (hi-lo)/2
+		v := arr[mid]
+		switch {
+		case v == target:
+			foundIdx = mid
+			// keep searching left for the first occurrence
+			hi = mid - 1
+		case v < target:
+			lo = mid + 1
+		default:
+			hi = mid - 1
+		}
+	}
+
+	if foundIdx >= 0 {
+		return foundIdx + 1, true, lo + 1 // insertPos still lo+1
+	}
+	return 0, false, lo + 1
+}
+
+// ensureAscending validates non-decreasing order (ascending) of `arr`.
+func ensureAscending(arr []float64) error {
+	if len(arr) <= 1 {
+		return nil
+	}
+	last := arr[0]
+	for i := 1; i < len(arr); i++ {
+		if arr[i] < last {
+			return fmt.Errorf("input data is not in ascending order at position %d: %.10g < %.10g", i+1, arr[i], last)
+		}
+		last = arr[i]
+	}
+	return nil
+}
+
+// -----------------------------
+// I/O helpers
+// -----------------------------
+
+// readNumbers reads float64s from reader, one per line (blank lines ignored).
+// Non-numeric lines are skipped with a warning to STDERR.
+func readNumbers(r io.Reader) ([]float64, error) {
+	sc := bufio.NewScanner(r)
+	// Increase buffer for very long lines (1 MiB)
+	buf := make([]byte, 0, 1024*1024)
+	sc.Buffer(buf, 1024*1024)
+
+	out := make([]float64, 0, 1024)
+	lineNo := 0
+	for sc.Scan() {
+		lineNo++
+		s := strings.TrimSpace(sc.Text())
+		if s == "" {
+			continue
+		}
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "WARN: skipping non-numeric line %d: %q\n", lineNo, s)
+			continue
+		}
+		out = append(out, v)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func readNumbersFromFile(path string) ([]float64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return readNumbers(f)
+}
+
+// -----------------------------
+// CLI glue
+// -----------------------------
+
+func usage(prog string) {
+	base := filepath.Base(prog)
+	fmt.Printf("Usage:\n")
+	fmt.Printf("  %s <target_number> <file_with_one_number_per_line>\n", base)
+	fmt.Printf("  %s <target_number>  # reads numbers from STDIN\n\n", base)
+	fmt.Printf("Example:\n")
+	fmt.Printf("  printf \"1\\n3\\n4\\n7\\n9\\n11\\n15\\n\" | %s 11\n", base)
+}
+
+func parseArgs() (float64, string, error) {
+	if len(os.Args) < 2 {
+		return 0, "", errors.New("missing target_number")
+	}
+	target, err := strconv.ParseFloat(os.Args[1], 64)
+	if err != nil {
+		return 0, "", fmt.Errorf("target_number must be numeric, got %q", os.Args[1])
+	}
+	file := ""
+	if len(os.Args) >= 3 {
+		file = os.Args[2]
+	}
+	return target, file, nil
+}
+
+func main() {
+	target, file, err := parseArgs()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR:", err)
+		usage(os.Args[0])
+		os.Exit(2)
+	}
+
+	var nums []float64
+	if file == "" {
+		nums, err = readNumbers(os.Stdin)
+	} else {
+		nums, err = readNumbersFromFile(file)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR:", err)
+		os.Exit(1)
+	}
+	if len(nums) == 0 {
+		fmt.Fprintln(os.Stderr, "ERROR: no numeric input provided")
+		os.Exit(1)
+	}
+	if err := ensureAscending(nums); err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR:", err)
+		os.Exit(1)
+	}
+
+	idx, found, ins := binarySearch(nums, target)
+	if found {
+		fmt.Printf("FOUND %g at index %d (1-based)\n", target, idx)
+	} else {
+		left := "-inf"
+		if ins-2 >= 0 {
+			left = fmt.Sprintf("%.10g", nums[ins-2])
+		}
+		right := "+inf"
+		if ins-1 < len(nums) {
+			right = fmt.Sprintf("%.10g", nums[ins-1])
+		}
+		fmt.Printf("NOT FOUND %g. Insertion index %d (1-based), between %s and %s\n",
+			target, ins, left, right)
+	}
+}
+

--- a/dev_src/015_binary_search_Scala.scala
+++ b/dev_src/015_binary_search_Scala.scala
@@ -1,0 +1,124 @@
+// BinarySearch.scala
+// Scala CLI: Binary search (first occurrence) on a sorted ascending array of integers.
+//
+// Build/Run (Scala 2.13 or 3.x):
+//   scalac BinarySearch.scala && scala BinarySearch <target> [path/to/file]
+//   # or via STDIN (one number per line):
+//   printf "1\n3\n4\n7\n9\n11\n15\n" | scala BinarySearch 11
+//
+// Behavior
+//   • O(log N) search; returns the FIRST index if duplicates exist (stable-left).
+//   • On hit : prints  FOUND <target> at index <i> (1-based)
+//   • On miss: prints  NOT FOUND <target>. Insertion index <i> (1-based), between <left> and <right>
+//   • Validates non-decreasing order; exits with error if violated.
+
+import scala.io.Source
+import scala.util.Try
+
+object BinarySearch {
+  def main(args: Array[String]): Unit = {
+    if (args.length < 1) {
+      Console.err.println("ERROR: missing <target>")
+      usage()
+      sys.exit(2)
+    }
+
+    val target: Long = Try(args(0).toLong).getOrElse {
+      Console.err.println(s"ERROR: target must be integer, got '${args(0)}'")
+      usage(); sys.exit(2); 0L
+    }
+
+    val numbers: Vector[Long] =
+      try {
+        if (args.length >= 2) readNumbers(Source.fromFile(args(1)))
+        else readNumbers(Source.stdin)
+      } catch {
+        case e: Exception =>
+          Console.err.println(s"ERROR: failed to read input: ${e.getMessage}")
+          sys.exit(1); Vector.empty
+      }
+
+    if (numbers.isEmpty) {
+      Console.err.println("ERROR: no numeric input provided.")
+      sys.exit(1)
+    }
+
+    ensureAscending(numbers) match {
+      case Some(err) =>
+        Console.err.println(err)
+        sys.exit(1)
+      case None => // ok
+    }
+
+    val (idx1, found, ins1) = binarySearchFirst(numbers, target)
+
+    if (found) {
+      println(s"FOUND $target at index $idx1 (1-based)")
+    } else {
+      val left  = if (ins1 >= 2) numbers(ins1 - 2).toString else "-inf"
+      val right = if ((ins1 - 1) < numbers.length) numbers(ins1 - 1).toString else "+inf"
+      println(s"NOT FOUND $target. Insertion index $ins1 (1-based), between $left and $right")
+    }
+  }
+
+  /** Read integers (one per line). Non-numeric lines are skipped with a warning. */
+  def readNumbers(src: Source): Vector[Long] = {
+    try {
+      val buf = Vector.newBuilder[Long]
+      var lineNo = 0
+      for (line <- src.getLines()) {
+        lineNo += 1
+        val s = line.trim
+        if (s.nonEmpty) {
+          Try(s.toLong).toOption match {
+            case Some(v) => buf += v
+            case None    => Console.err.println(s"WARN: skipping non-integer line $lineNo: $s")
+          }
+        }
+      }
+      buf.result()
+    } finally src.close()
+  }
+
+  /** Ensure non-decreasing order; return Some(errorMsg) if violated. */
+  def ensureAscending(a: Vector[Long]): Option[String] = {
+    var i = 1
+    while (i < a.length) {
+      if (a(i) < a(i - 1))
+        return Some(s"ERROR: input not in ascending order at position ${i + 1}: ${a(i)} < ${a(i - 1)}")
+      i += 1
+    }
+    None
+  }
+
+  /** Binary search for first occurrence (stable-left).
+    * Returns (index_1based, found, insertion_index_1based).
+    */
+  def binarySearchFirst(a: Vector[Long], target: Long): (Int, Boolean, Int) = {
+    var lo = 0
+    var hi = a.length - 1
+    var found = -1
+
+    while (lo <= hi) {
+      val mid = lo + (hi - lo) / 2
+      val v = a(mid)
+      if (v == target) {
+        found = mid
+        hi = mid - 1 // keep searching left
+      } else if (v < target) {
+        lo = mid + 1
+      } else {
+        hi = mid - 1
+      }
+    }
+
+    if (found >= 0) (found + 1, true, lo + 1)
+    else (0, false, lo + 1)
+  }
+
+  def usage(): Unit = {
+    Console.err.println("Usage:")
+    Console.err.println("  scala BinarySearch <target> [path/to/file]")
+    Console.err.println("""  printf "1\n3\n4\n7\n9\n11\n15\n" | scala BinarySearch 11""")
+  }
+}

--- a/dev_src/025_binary_search_VB_NET.vb
+++ b/dev_src/025_binary_search_VB_NET.vb
@@ -1,0 +1,121 @@
+' Program.vb — Binary search (lower-bound) over a sorted ascending list.
+' Build (Windows or Linux/OSX with .NET SDK):
+'   dotnet new console -n BinSearchVB -f net8.0
+'   mv Program.vb BinSearchVB/Program.vb
+'   cd BinSearchVB && dotnet run -- <path_or_->_ <target_int>
+'
+' Usage:
+'   dotnet run -- <path_or_->_ <target_int>
+'     <path_or_->_ : path to a text file with one integer per line; use "-" for STDIN
+'     <target_int> : integer to search for (Int64)
+'
+' Behavior:
+'   • Ignores blank lines and lines that can’t be parsed as integers (prints a warning count).
+'   • Verifies ascending (non-decreasing) order before searching.
+'   • Performs lower-bound binary search (first index with a(i) >= target), 1-based reporting.
+
+Imports System
+Imports System.IO
+Imports System.Collections.Generic
+
+Module Program
+
+  Sub Main(args As String())
+    If args.Length < 2 Then
+      Console.WriteLine("Usage: dotnet run -- <path_or_->_ <target_int>")
+      Console.WriteLine("Example:")
+      Console.WriteLine("  printf ""1\n3\n4\n7\n9\n11\n15\n"" | dotnet run -- - 11")
+      Environment.
+    End If
+
+    Dim src As String = args(0).Trim()
+    Dim target As Long
+    If Not Int64.TryParse(args(1), target) Then
+      Console.Error.WriteLine($"ERROR: TARGET must be an integer, got: {args(1)}")
+      Environment.
+    End If
+
+    Dim data As New List(Of Long)(capacity:=1024)
+    Dim skipped As Integer = 0
+
+    If src = "-"c Then
+      ReadStream(Console.In, data, skipped)
+    Else
+      Try
+        Using sr As New StreamReader(src)
+          ReadStream(sr, data, skipped)
+        End Using
+      Catch ex As Exception
+        Console.Error.WriteLine($"ERROR: Cannot open file: {src} ({ex.Message})")
+        Environment.
+      End Try
+    End If
+
+    If skipped > 0 Then
+      Console.WriteLine($"WARN: skipped {skipped} non-integer line(s).")
+    End If
+    If data.Count = 0 Then
+      Console.Error.WriteLine("ERROR: No numeric input found.")
+      Environment.
+    End If
+
+    Dim badPair As (Long, Long) = CheckSorted(data)
+    If badPair.Item1 <> 0 OrElse badPair.Item2 <> 0 Then
+      Console.Error.WriteLine($"ERROR: Input not in ascending order near {badPair.Item1} then {badPair.Item2}")
+      Environment.
+    End If
+
+    Dim pos As Integer = LowerBound(data, target) ' 0-based position where a(pos) >= target
+    If pos < data.Count AndAlso data(pos) = target Then
+      Console.WriteLine($"FOUND {target} at index {pos + 1}")
+    Else
+      Dim leftVal As String = If(pos > 0, data(pos - 1).ToString(), "-inf")
+      Dim rightVal As String = If(pos < data.Count, data(pos).ToString(), "+inf")
+      Console.WriteLine($"NOT FOUND {target}. Insertion index {pos + 1} (1-based), between {leftVal} and {rightVal}")
+    End If
+  End Sub
+
+  ' Read integers from a TextReader, appending into list; count non-integer lines.
+  Private Sub ReadStream(r As TextReader, ByRef acc As List(Of Long), ByRef skipped As Integer)
+    Dim line As String
+    Do
+      line = r.ReadLine()
+      If line Is Nothing Then Exit Do
+      Dim s As String = line.Trim()
+      If s.Length = 0 Then Continue Do
+      Dim v As Long
+      If Int64.TryParse(s, v) Then
+        acc.Add(v)
+      Else
+        skipped += 1
+      End If
+    Loop
+  End Sub
+
+  ' Return (0,0) if sorted non-decreasing; otherwise the offending adjacent pair (prev, curr).
+  Private Function CheckSorted(a As List(Of Long)) As (Long, Long)
+    For i As Integer = 1 To a.Count - 1
+      If a(i) < a(i - 1) Then
+        Return (a(i - 1), a(i))
+      End If
+    Next
+    Return (0L, 0L)
+  End Function
+
+  ' LowerBound: first index i in [0..n] with a(i) >= target (if none, returns n).
+  Private Function LowerBound(a As List(Of Long), target As Long) As Integer
+    Dim lo As Integer = 0
+    Dim hi As Integer = a.Count
+    While lo < hi
+      Dim mid As Integer = lo + (hi - lo) \ 2
+      If a(mid) < target Then
+        lo = mid + 1
+      Else
+        hi = mid
+      End If
+    End While
+    Return lo
+  End Function
+
+End Module
+

--- a/dev_src/061_shortest_path_MATLAB.m
+++ b/dev_src/061_shortest_path_MATLAB.m
@@ -1,0 +1,180 @@
+% bfs_unweighted.m
+% Breadth-first search (BFS) shortest path on an unweighted, undirected graph.
+% INPUT FORMAT (tab- or space-separated; one edge per line; queries start with '#'):
+%   A   B   F
+%   B   A   C
+%   ...
+%   #   SRC DST
+%
+% Run examples (in MATLAB/Octave Command Window):
+%   % From a file:
+%   run_bfs_unweighted('graph.tsv');
+%   % From a string (e.g., copy-pasted sample):
+%   txt = sprintf('A\tB\tF\nB\tA\tC\nC\tB\tD\nD\tC\tE\nE\tD\tF\nF\tA\tE\n#\tA\tE\n');
+%   run_bfs_unweighted(txt);
+%
+% Outputs one line per query as: "SRC -> ... -> DST" or an explanatory message.
+
+function run_bfs_unweighted(inputSource)
+  if nargin < 1
+    error('Usage: run_bfs_unweighted(inputSource) where inputSource is a file path OR a char/string with the contents.');
+  end
+
+  %---- Load lines ----------------------------------------------------------
+  if ischar(inputSource) || (isstring(inputSource) && isscalar(inputSource))
+    if isfile(inputSource)  % treat as path
+      raw = fileread(inputSource);
+    else                    % treat as literal contents
+      raw = char(inputSource);
+    end
+  else
+    error('inputSource must be a file path or a string with the file contents.');
+  end
+  raw = regexprep(raw, '\r\n?', '\n');             % normalize newlines
+  L = regexp(raw, '\n', 'split');                  % cellstr lines
+
+  %---- Parse into adjacency and queries -----------------------------------
+  adj = containers.Map('KeyType','char','ValueType','any');  % node -> cellstr neighbors
+  queries = {};  % N x 2 cell array of {src, dst}
+
+  for i = 1:numel(L)
+    line = strtrim(L{i});
+    if isempty(line)
+      continue
+    end
+    % split by any run of tabs/spaces
+    toks = regexp(line, '[\t ]+', 'split');
+    if isempty(toks)
+      continue
+    end
+
+    if startsWith(toks{1}, '#')
+      if numel(toks) < 3
+        warning('Skipping malformed query line %d: "%s"', i, line);
+        continue
+      end
+      src = toks{2}; dst = toks{3};
+      queries(end+1,1:2) = {src, dst}; %#ok<AGROW>
+    else
+      % edge row: NODE NEI1 [NEI2]
+      if numel(toks) < 2
+        warning('Skipping malformed edge line %d: "%s"', i, line);
+        continue
+      end
+      u = toks{1};
+      v1 = toks{2};
+      if ~isempty(v1)
+        adj = add_undirected_edge(adj, u, v1);
+      end
+      if numel(toks) >= 3
+        v2 = toks{3};
+        if ~isempty(v2)
+          adj = add_undirected_edge(adj, u, v2);
+        end
+      end
+    end
+  end
+
+  if isempty(queries)
+    fprintf('No queries found (lines starting with "#\\tSRC\\tDST"). Nothing to do.\n');
+    return
+  end
+
+  %---- Answer queries with BFS --------------------------------------------
+  for q = 1:size(queries,1)
+    src = queries{q,1};
+    dst = queries{q,2};
+
+    if ~isKey(adj, src)
+      fprintf('No path found from %s to %s (source not in graph)\n', src, dst);
+      continue
+    end
+    if ~strcmp(src, dst) && ~isKey(adj, dst)
+      fprintf('No path found from %s to %s (destination not in graph)\n', src, dst);
+      continue
+    end
+    if strcmp(src, dst)
+      fprintf('%s\n', src);
+      continue
+    end
+
+    path = bfs_path(adj, src, dst);
+    if isempty(path)
+      fprintf('No path found from %s to %s\n', src, dst);
+    else
+      fprintf('%s\n', strjoin(path, ' -> '));
+    end
+  end
+end
+
+%==================== Helpers ====================%
+
+function adj = add_undirected_edge(adj, u, v)
+  % Add u<->v (unique neighbors)
+  adj = add_directed_unique(adj, u, v);
+  adj = add_directed_unique(adj, v, u);
+end
+
+function adj = add_directed_unique(adj, u, v)
+  if ~isKey(adj, u)
+    adj(u) = {v};
+    return
+  end
+  lst = adj(u);
+  % ensure uniqueness; treat as strings
+  if ~any(strcmp(lst, v))
+    lst{end+1} = v; %#ok<AGROW>
+    adj(u) = lst;
+  end
+end
+
+function path = bfs_path(adj, src, dst)
+  % Classic BFS to reconstruct shortest unweighted path.
+  % Uses cell arrays as queue for O(1) amortized via head index.
+  visited = containers.Map('KeyType','char','ValueType','logical');
+  parent  = containers.Map('KeyType','char','ValueType','char');
+
+  queue = {src};
+  head = 1;
+  visited(src) = true;
+  parent(src) = '';  % sentinel
+
+  found = false;
+  while head <= numel(queue)
+    u = queue{head}; head = head + 1;
+
+    if strcmp(u, dst)
+      found = true;
+      break
+    end
+
+    if isKey(adj, u)
+      nei = adj(u);
+      for k = 1:numel(nei)
+        v = nei{k};
+        if ~isKey(visited, v)
+          visited(v) = true;
+          parent(v)  = u;
+          queue{end+1} = v; %#ok<AGROW>
+        end
+      end
+    end
+  end
+
+  if ~found
+    path = {};
+    return
+  end
+
+  % Reconstruct from dst -> src
+  rev = {dst};
+  cur = dst;
+  while true
+    p = parent(cur);
+    if isempty(p), break; end
+    rev{end+1} = p; %#ok<AGROW>
+    cur = p;
+  end
+  path = rev(end:-1:1);
+end
+

--- a/dev_src/068_shortest_path_Haskell.hs
+++ b/dev_src/068_shortest_path_Haskell.hs
@@ -1,0 +1,132 @@
+-- BFSShortestPath.hs
+-- Breadth-first search for shortest path(s) on an unweighted, UNDIRECTED graph.
+--
+-- INPUT FORMAT (whitespace-separated):
+--   Edge lines : "U  V1 [V2 ...]"  => add undirected edges U—V1, U—V2, ...
+--   Query line : "#  SRC DST"      => ask for a shortest path SRC -> DST
+--
+-- Example:
+--   A   B   F
+--   B   A   C
+--   C   B   D
+--   D   C   E
+--   E   D   F
+--   F   A   E
+--   #   A   E
+--
+-- USAGE
+--   runhaskell BFSShortestPath.hs < graph.tsv
+--   # or compile:
+--   ghc -O2 BFSShortestPath.hs && ./BFSShortestPath < graph.tsv
+--   # or provide a file path:
+--   runhaskell BFSShortestPath.hs path/to/graph.tsv
+
+{-# LANGUAGE TupleSections #-}
+
+import qualified Data.Map.Strict as M
+import qualified Data.Set as S
+import qualified Data.Sequence as Q
+import           Data.Foldable  (toList)
+import           System.Environment (getArgs)
+import           System.IO (readFile)
+import           Data.Maybe (fromMaybe)
+
+-- ------------------------------- Types ----------------------------------
+
+type Node  = String
+type Graph = M.Map Node [Node]
+
+-- ------------------------------- Main -----------------------------------
+
+main :: IO ()
+main = do
+  args <- getArgs
+  contents <- case args of
+    (fp:_) -> readFile fp
+    _      -> getContents
+  let ls = filter (not . null) . map strip $ lines contents
+      (g, queries) = parseInput ls
+  if null queries
+    then putStrLn "No queries found (expected lines like: \"# SRC DST\")."
+    else mapM_ (answer g) queries
+
+answer :: Graph -> (Node, Node) -> IO ()
+answer g (s, t)
+  | s == t = putStrLn s
+  | not (M.member s g) = putStrLn $ "No path found from " ++ s ++ " to " ++ t ++ " (source not in graph)"
+  | not (M.member t g) = putStrLn $ "No path found from " ++ s ++ " to " ++ t ++ " (destination not in graph)"
+  | otherwise =
+      case bfsPath g s t of
+        Just path -> putStrLn (joinWith " -> " path)
+        Nothing   -> putStrLn $ "No path found from " ++ s ++ " to " ++ t
+
+-- ------------------------------ Parsing ---------------------------------
+
+parseInput :: [String] -> (Graph, [(Node, Node)])
+parseInput = finalize . foldl step (M.empty :: M.Map Node (S.Set Node), [] :: [(Node,Node)])
+  where
+    step (g, qs) ln =
+      case words ln of
+        []           -> (g, qs)
+        ("#":a:b:_)  -> (g, qs ++ [(a,b)])
+        (u:vs)       -> (foldl (\acc v -> addUndirected acc u v) (ensureNode (ensureNode g u) u) vs, qs)
+        _            -> (g, qs)
+    finalize (g, qs) = (M.map (toList) (M.map S.toAscList g), qs)
+
+-- Add undirected edge u—v, keep neighbor sets deduplicated
+addUndirected :: M.Map Node (S.Set Node) -> Node -> Node -> M.Map Node (S.Set Node)
+addUndirected g u v =
+  let g'  = ensureNode g u
+      g'' = ensureNode g' v
+  in M.adjust (S.insert v) u $ M.adjust (S.insert u) v g''
+
+ensureNode :: M.Map Node (S.Set Node) -> Node -> M.Map Node (S.Set Node)
+ensureNode g u = if M.member u g then g else M.insert u S.empty g
+
+-- ------------------------------- BFS ------------------------------------
+
+-- Return shortest path [src,...,dst] or Nothing if unreachable.
+bfsPath :: Graph -> Node -> Node -> Maybe [Node]
+bfsPath g src dst =
+  let q0       = Q.singleton src
+      visited0 = S.singleton src
+      parent0  = M.empty :: M.Map Node Node
+  in bfsLoop q0 visited0 parent0
+  where
+    bfsLoop q visited parent =
+      case Q.viewl q of
+        Q.EmptyL     -> Nothing
+        u Q.:< qrest ->
+          let nbrs = fromMaybe [] (M.lookup u g)
+              step (q', vis', par', found) v
+                | found               = (q', vis', par', True)
+                | S.member v vis'     = (q', vis', par', False)
+                | v == dst            = (q', S.insert v vis', M.insert v u par', True)
+                | otherwise           = (q' Q.|> v, S.insert v vis', M.insert v u par', False)
+              (q1, vis1, par1, hit) = foldl step (qrest, visited, parent, False) nbrs
+          in if hit
+               then Just (reconstruct par1 src dst)
+               else bfsLoop q1 vis1 par1
+
+reconstruct :: M.Map Node Node -> Node -> Node -> [Node]
+reconstruct parent src dst = reverse (go dst [])
+  where
+    go cur acc
+      | cur == src = src : acc
+      | otherwise  = case M.lookup cur parent of
+                       Just p  -> go p (cur:acc)
+                       Nothing -> acc  -- shouldn't happen if called correctly
+
+-- ------------------------------ Utilities --------------------------------
+
+strip :: String -> String
+strip = rstrip . lstrip
+  where
+    lstrip = dropWhile (`elem` [' ', '\t', '\r'])
+    rstrip = reverse . lstrip . reverse
+
+joinWith :: String -> [String] -> String
+joinWith _ []     = ""
+joinWith _ [x]    = x
+joinWith sep (x:xs) = x ++ concatMap (sep ++) xs
+

--- a/dev_src/070_shortest_path_Lisp.lisp
+++ b/dev_src/070_shortest_path_Lisp.lisp
@@ -1,0 +1,214 @@
+;;;; bfs_shortest_path.lisp
+;;;; Common Lisp script: Breadth-First Search (BFS) shortest path on an unweighted, UNDIRECTED graph.
+;;;;
+;;;; INPUT (whitespace/tab separated):
+;;;;   Edge lines : "U  V1 [V2 ...]"  => add undirected edges U—V1, U—V2, ...
+;;;;   Query line : "#  SRC DST"      => request one shortest path from SRC to DST
+;;;;
+;;;; Example:
+;;;;   A   B   F
+;;;;   B   A   C
+;;;;   C   B   D
+;;;;   D   C   E
+;;;;   E   D   F
+;;;;   F   A   E
+;;;;   #   A   E
+;;;;
+;;;; USAGE
+;;;;   sbcl --script bfs_shortest_path.lisp < graph.tsv
+;;;;   # or
+;;;;   sbcl --script bfs_shortest_path.lisp graph.tsv
+;;;;
+;;;; OUTPUT
+;;;;   For each query line, either a path like "A -> B -> C" or "No path found from SRC to DST".
+
+;;;; ------------------------------------------------------------
+;;;; Utilities
+;;;; ------------------------------------------------------------
+
+(defun split-on-whitespace (line)
+  "Return a list of non-empty tokens split on runs of whitespace in LINE."
+  (let ((len (length line))
+        (tokens '())
+        (start nil))
+    (labels ((whitespacep (ch)
+               (or (char= ch #\Space)
+                   (char= ch #\Tab)
+                   (char= ch #\Newline)
+                   (char= ch #\Return))))
+      (loop for i from 0 below len
+            for ch = (char line i) do
+              (cond
+                ((whitespacep ch)
+                 (when start
+                   (push (subseq line start i) tokens)
+                   (setf start nil)))
+                (t
+                 (unless start (setf start i)))))
+      (when start
+        (push (subseq line start len) tokens))
+      (nreverse tokens))))
+
+(defun ensure (table key &key (value-maker (lambda () (make-hash-table :test #'equal))))
+  "Ensure TABLE has KEY; if absent, set to (FUNCALL VALUE-MAKER) and return it.
+For presence, return existing value."
+  (multiple-value-bind (val presentp) (gethash key table)
+    (if presentp
+        val
+        (setf (gethash key table) (funcall value-maker)))))
+
+(defun add-undirected-edge (graph u v)
+  "Add undirected edge u—v to GRAPH (a hash-table of node => neighbor-set (hash-table))."
+  (let ((nu (ensure graph u))
+        (nv (ensure graph v)))
+    (setf (gethash v nu) t)
+    (setf (gethash u nv) t)))
+
+(defun read-all-lines (stream)
+  "Read all lines from STREAM, return list of strings in order."
+  (let ((lines '()))
+    (loop for line = (read-line stream nil :eof)
+          until (eq line :eof)
+          do (push line lines))
+    (nreverse lines)))
+
+(defun get-cmd-args ()
+  "Return command line arguments (excluding the script path) portably across common CLs.
+If not detected, return NIL."
+  (cond
+    (#-sbcl nil #+sbcl (cdr sb-ext:*posix-argv*))
+    (#-ccl nil #+ccl ccl:*unprocessed-command-line-arguments*)
+    (#-ecl nil #+ecl (ext:command-args))
+    (#-clisp nil #+clisp (ext:argv))
+    (t nil)))
+
+;;;; ------------------------------------------------------------
+;;;; Queue (simple linked-list tail queue)
+;;;; ------------------------------------------------------------
+
+(defstruct (queue (:constructor make-queue))
+  head
+  tail)
+
+(defun q-empty-p (q) (null (queue-head q)))
+
+(defun q-enqueue (q item)
+  "Enqueue ITEM in Q in O(1)."
+  (let ((cell (list item)))
+    (if (queue-tail q)
+        (setf (cdr (queue-tail q)) cell
+              (queue-tail q) cell)
+        (setf (queue-head q) cell
+              (queue-tail q) cell)))
+  q)
+
+(defun q-dequeue (q)
+  "Dequeue and return next item from Q, or NIL if empty."
+  (let ((h (queue-head q)))
+    (when h
+      (let ((item (car h)))
+        (setf (queue-head q) (cdr h))
+        (unless (queue-head q)
+          (setf (queue-tail q) nil))
+        item))))
+
+;;;; ------------------------------------------------------------
+;;;; BFS Shortest Path
+;;;; ------------------------------------------------------------
+
+(defun bfs-shortest-path (graph src dst)
+  "Return shortest path as a list of node labels from SRC to DST inclusive, or NIL if unreachable.
+GRAPH is a hash-table mapping node(string) => neighbor-set(hash-table)."
+  (when (string= src dst)
+    (return-from bfs-shortest-path (list src)))
+  (unless (and (gethash src graph) (gethash dst graph))
+    (return-from bfs-shortest-path nil))
+  (let ((visited (make-hash-table :test #'equal))
+        (parent  (make-hash-table :test #'equal))
+        (q (make-queue)))
+    (setf (gethash src visited) t)
+    (q-enqueue q src)
+    (loop until (q-empty-p q) do
+      (let* ((u (q-dequeue q))
+             (neighbors (gethash u graph)))
+        (maphash
+         (lambda (v _)
+           (declare (ignore _))
+           (unless (gethash v visited)
+             (setf (gethash v visited) t
+                   (gethash v parent)  u)
+             (when (string= v dst)
+               (return-from bfs-shortest-path
+                 (labels ((reconstruct (cur acc)
+                            (if (string= cur src)
+                                (cons src acc)
+                                (reconstruct (gethash cur parent) (cons cur acc)))))
+                   (reconstruct v '()))))
+             (q-enqueue q v)))
+         neighbors)))
+    nil))
+
+(defun join-with (items sep)
+  "Join list of strings ITEMS with separator SEP."
+  (with-output-to-string (out)
+    (loop for item in items
+          for i from 0 do
+            (when (> i 0) (princ sep out))
+            (princ item out))))
+
+;;;; ------------------------------------------------------------
+;;;; Parsing + Main
+;;;; ------------------------------------------------------------
+
+(defun parse-graph-and-queries (lines)
+  "Parse LINES (list of strings). Return (values GRAPH QUERIES).
+GRAPH: hash-table node=>neighbor-set
+QUERIES: list of (SRC . DST)."
+  (let ((graph (make-hash-table :test #'equal))
+        (queries '()))
+    (dolist (ln lines)
+      (let ((ln (string-trim '(#\Space #\Tab #\Return #\Newline) ln)))
+        (when (plusp (length ln))
+          (let ((parts (split-on-whitespace ln)))
+            (when parts
+              (if (string= (first parts) "#")
+                  (when (>= (length parts) 3)
+                    (push (cons (second parts) (third parts)) queries))
+                  (let ((u (first parts)))
+                    (ensure graph u) ; ensure node exists even if isolated
+                    (dolist (v (rest parts))
+                      (add-undirected-edge graph u v)))))))))
+    (values graph (nreverse queries))))
+
+(defun run (in-stream)
+  (multiple-value-bind (graph queries)
+      (parse-graph-and-queries (read-all-lines in-stream))
+    (if (null queries)
+        (format *error-output* "No queries found (expected lines like: \"# SRC DST\").~%")
+        (dolist (q queries)
+          (destructuring-bind (src . dst) q
+            (let ((path (bfs-shortest-path graph src dst)))
+              (if path
+                  (format t "~a~%" (join-with path " -> "))
+                  (format t "No path found from ~a to ~a~%" src dst))))))))
+
+(defun main ()
+  "Entry point: reads from file path given on CLI or from STDIN."
+  (let* ((args (get-cmd-args))
+         (file (and args (second args)))) ; first arg is the implementation path in some CLs
+    (cond
+      ((and file (not (string= file "")) (probe-file file))
+       (with-open-file (in file :direction :input :external-format :utf-8)
+         (run in)))
+      (t
+       (run *standard-input*)))))
+
+;;;; ------------------------------------------------------------
+;;;; Auto-run when used as a 'script'
+;;;; ------------------------------------------------------------
+;; Many CLs set *LOAD-TRUENAME* when loading; when run via --script, call MAIN.
+(when (or (member :sbcl *features*) (member :ccl *features*) (member :ecl *features*) (member :clisp *features*))
+  (when (and (boundp '*load-truename*) *load-truename*)
+    ;; If being loaded as a script, try to run MAIN. This is harmless if loaded in REPL.
+    (ignore-errors (main))))
+

--- a/dev_src/074_shortest_path_Elixir.exs
+++ b/dev_src/074_shortest_path_Elixir.exs
@@ -1,0 +1,172 @@
+# bfs_shortest_path.exs
+# Breadth-First Search (BFS) shortest path on an unweighted, UNDIRECTED graph.
+#
+# INPUT format (whitespace separated), one line per record:
+#   Edge line  : "U  V1 [V2 ...]"  -> add undirected edges U—V1, U—V2, ...
+#   Node line  : "U"               -> ensure node exists (even if isolated)
+#   Query line : "#  SRC DST"      -> request one shortest path from SRC to DST
+#
+# Example (TSV-style; tabs or spaces both fine):
+#   A   B   F
+#   B   A   C
+#   C   B   D
+#   D   C   E
+#   E   D   F
+#   F   A   E
+#   #   A   E
+#
+# RUN (choose one):
+#   1) elixir bfs_shortest_path.exs < graph.tsv
+#   2) elixir bfs_shortest_path.exs graph.tsv
+#
+# OUTPUT:
+#   For each query line, either "A -> B -> C" or "No path found from SRC to DST".
+
+defmodule BFSShortestPath do
+  @moduledoc false
+
+  # -------- Entry point --------
+
+  def main(argv) do
+    stream =
+      case argv do
+        [] -> IO.stream(:stdio, :line)
+        [path] -> File.stream!(path, [], :line)
+        _ ->
+          IO.puts(:stderr, "Usage: elixir bfs_shortest_path.exs [graph.tsv]\n(Reads STDIN if no file given)")
+          System.halt(2)
+      end
+
+    {graph, queries} = parse_stream(stream)
+
+    if queries == [] do
+      IO.puts("No queries found (expected lines beginning with: \"# SRC DST\").")
+    else
+      Enum.each(queries, fn {src, dst} ->
+        case bfs_shortest_path(graph, src, dst) do
+          {:ok, path} -> IO.puts(Enum.join(path, " -> "))
+          :not_found  -> IO.puts("No path found from #{src} to #{dst}")
+        end
+      end)
+    end
+  end
+
+  # -------- Parsing (single pass, streaming) --------
+
+  # Graph: %{
+  #   "Node" => MapSet.new(["Neighbor1","Neighbor2",...]),
+  #   ...
+  # }
+  # Queries: [{src, dst}, ...]
+  defp parse_stream(lines_enum) do
+    Enum.reduce(lines_enum, {%{}, []}, fn raw, {graph, queries} ->
+      tokens =
+        raw
+        |> String.trim()
+        |> String.split(~r/\s+/, trim: true)
+
+      case tokens do
+        [] ->
+          {graph, queries}
+
+        ["#", src, dst | _] ->
+          {graph, [{src, dst} | queries]}
+
+        [u] ->
+          {ensure_node(graph, u), queries}
+
+        [u | vs] ->
+          g = ensure_node(graph, u)
+
+          g2 =
+            Enum.reduce(vs, g, fn v, acc ->
+              acc
+              |> add_undirected_edge(u, v)
+            end)
+
+          {g2, queries}
+      end
+    end)
+    |> then(fn {g, qs} -> {g, Enum.reverse(qs)} end)
+  end
+
+  defp ensure_node(graph, u), do: Map.put_new(graph, u, MapSet.new())
+
+  defp add_undirected_edge(graph, u, v) do
+    graph
+    |> Map.update(u, MapSet.new([v]), &MapSet.put(&1, v))
+    |> Map.update(v, MapSet.new([u]), &MapSet.put(&1, u))
+  end
+
+  # -------- BFS shortest path --------
+
+  # Trivial same-node case
+  defp bfs_shortest_path(graph, src, dst) when src == dst do
+    if Map.has_key?(graph, src), do: {:ok, [src]}, else: :not_found
+  end
+
+  defp bfs_shortest_path(graph, src, dst) do
+    cond do
+      not Map.has_key?(graph, src) -> :not_found
+      not Map.has_key?(graph, dst) -> :not_found
+      true ->
+        visited = MapSet.new([src])
+        parents = %{} # child -> parent
+        queue   = :queue.from_list([src])
+        bfs_loop(graph, dst, queue, visited, parents)
+    end
+  end
+
+  defp bfs_loop(_graph, _dst, queue, _visited, _parents) do
+    case :queue.out(queue) do
+      {:empty, _} ->
+        :not_found
+
+      {{:value, u}, q1} ->
+        neighbors = Map.get(_graph, u, MapSet.new()) |> MapSet.to_list()
+
+        case scan_neighbors(neighbors, u, q1, _visited, _parents, _graph, _dst) do
+          {:found, parents2, dst} ->
+            {:ok, reconstruct_path(parents2, dst)}
+
+          {:cont, qn, vn, pn} ->
+            bfs_loop(_graph, _dst, qn, vn, pn)
+        end
+    end
+  end
+
+  # Visit neighbors of current node `u`; enqueue unseen; capture parent pointers.
+  defp scan_neighbors([], _u, q, visited, parents, _graph, _dst),
+    do: {:cont, q, visited, parents}
+
+  defp scan_neighbors([v | vs], u, q, visited, parents, graph, dst) do
+    if MapSet.member?(visited, v) do
+      scan_neighbors(vs, u, q, visited, parents, graph, dst)
+    else
+      visited1 = MapSet.put(visited, v)
+      parents1 = Map.put(parents, v, u)
+
+      if v == dst do
+        {:found, parents1, dst}
+      else
+        scan_neighbors(vs, u, :queue.in(v, q), visited1, parents1, graph, dst)
+      end
+    end
+  end
+
+  # Reconstruct path from parents map (which contains dst->...->src chain).
+  defp reconstruct_path(parents, dst) do
+    dst
+    |> Stream.unfold(fn cur ->
+      case cur do
+        nil -> nil
+        node -> {node, Map.get(parents, node)}
+      end
+    end)
+    |> Enum.reverse()
+  end
+end
+
+# -- Script entrypoint (Elixir "traditional" for .exs) --
+BFSShortestPath.main(System.argv())
+


### PR DESCRIPTION
Simplify retry semantics. Avoid redundant I/O calls. Extended coverage to large batch operations